### PR TITLE
Use 'dim' instead of 'length' to determine matrix dimensions

### DIFF
--- a/R/fftwtools.R
+++ b/R/fftwtools.R
@@ -218,7 +218,7 @@ fftw_r2c_2d <- function(data, HermConj=1) {
     nC <- dim(data)[2]
     nRc <- floor(nR/2) +1
     
-    idxRowAppend <- (nR - floor(nR/2)):2
+    idxRowAppend <- ceiling(nR/2):2
 
     ##correct for the fact the c call is column-major
 

--- a/R/fftwtools.R
+++ b/R/fftwtools.R
@@ -217,7 +217,7 @@ fftw_r2c_2d <- function(data, HermConj=1) {
     nR <- dim(data)[1]
     nC <- dim(data)[2]
     nRc <- floor(nR/2) +1
-    idxRowAppend <- (nRc - (nRc %% 2)):2
+    idxRowAppend <- (nR - floor(nR/2)):2
 
     ##correct for the fact the c call is column-major
 

--- a/R/fftwtools.R
+++ b/R/fftwtools.R
@@ -135,8 +135,8 @@ fftw_c2c <- function(data, inverse=0) {
 mvfftw_r2c <- function(data, HermConj=1, fftplanopt=0) {
 
     data <- as.matrix(data)
-    n <- length(data[,1])
-    m <- length(data[1,]) ## ncol
+    n <- dim(data)[1]
+    m <- dim(data)[2] ## ncol
 
     nc <- as.integer(n/2) +1
        
@@ -172,7 +172,6 @@ mvfftw_c2r <- function(data, HermConj=1, n=NULL, fftplanopt=0) {
     ## in this case the Hermatian conjugate must be stripped from the data.
 
     data <- as.matrix(data)
-    ##n <- length(data[,1])
     len <- dim(data)[1]
     m <- dim(data)[2]
     nc <- NULL
@@ -197,8 +196,8 @@ mvfftw_c2r <- function(data, HermConj=1, n=NULL, fftplanopt=0) {
 mvfftw_c2c <- function(data, inverse=0, fftplanopt=0) {
 
     data <- as.matrix(data)
-    n <- length(data[,1])
-    m <- length(data[1,])
+    n <- dim(data)[1]
+    m <- dim(data)[2]
     
     out <- .C("mvfft_c2c", as.integer(n), as.integer(m),
               as.complex(data),
@@ -215,8 +214,8 @@ fftw_r2c_2d <- function(data, HermConj=1) {
 
     data <- as.matrix(data)
 
-    nR <- length(data[,1])
-    nC <- length(data[1,])
+    nR <- dim(data)[1]
+    nC <- dim(data)[2]
     nRc <- floor(nR/2) +1
     idxRowAppend <- (nRc - (nRc %% 2)):2
 
@@ -251,8 +250,8 @@ fftw_c2c_2d <- function(data, inverse=0) {
 
     data <- as.matrix(data)
 
-    nR <- length(data[,1])
-    nC <- length(data[1,])
+    nR <- dim(data)[1]
+    nC <- dim(data)[2]
 
     ##we correct for the fact the c call is column-major
 


### PR DESCRIPTION
Dear Karim,
please consider the suggested change of switching in your code from 'length' to 'dim' for extracting matrix dimensions.

Using 'dim' is a preferred way of obtaining array dimensions in R. It does not create any temporary vectors and therefore it typically is an order of magnitude faster. You can assess this by yourself by running the simple benchmark below.

Cheers,
Andrzej


    library(microbenchmark)
    data = matrix(1, 1000, 2000)
    
    microbenchmark(
      {
        length(data[,1])
        length(data[1,])
      },
      {
        dim(data)[1]
        dim(data)[2]
      }
    )


