### PR TITLE
Multidim FFT for general arrays in R.

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,3 +1,3 @@
 #exportPattern("^[^\\.]")
-export( fftw, fftw2d, fftw_c2c, fftw_c2c_2d, fftw_c2r, fftw_r2c, fftw_r2c_2d, mvfftw, mvfftw_c2c, mvfftw_c2r, mvfftw_r2c)
+export( fftw, fftw2d, fftw_c2c, fftw_c2c_2d, fftw_c2c_xd, fftw_c2r, fftw_r2c, fftw_r2c_2d, mvfftw, mvfftw_c2c, mvfftw_c2r, mvfftw_r2c)
 useDynLib(fftwtools, .registration = TRUE)

--- a/R/fftwtools.R
+++ b/R/fftwtools.R
@@ -275,3 +275,19 @@ fftw_c2c_2d <- function(data, inverse=0) {
 
     return(out$res)
 }
+
+fftw_c2c_xd <- function(data, inverse=0) {
+
+    n <- dim(data)
+    r <- length(n)
+
+    ##we correct for the fact the c call is column-major
+    n <- rev(n)
+
+    out <- .C("cfft_c2c_xd", as.integer(r), as.integer(n),
+              as.complex(data),
+              res=array(as.complex(0), rev(n)),
+              as.integer(inverse))
+
+    return(out$res)
+}

--- a/man/fftw2d.Rd
+++ b/man/fftw2d.Rd
@@ -28,6 +28,7 @@
 \alias{fftw2d}
 \alias{fftw_c2c_2d}
 \alias{fftw_r2c_2d}
+\alias{fftw_c2c_xd}
 \title{Compute a two-dimensional FFT on a matrix using FFTW3}
 \description{
   Computes two-dimensional FFT on a matrix using the FFTW3 libraries.
@@ -36,21 +37,24 @@
   convention when returning the inverse of the FFT. For the two-dimension
   fft, the inverse is currently requires the entire matrix, including the
   redundant complex conjugate.
+
+  The function \code{fftw_c2c_xd} can calculate a higher dimensional FFT on a higher dimensional array.
 }
 \usage{
 fftw2d(data, inverse=0, HermConj=1)
 fftw_r2c_2d(data, HermConj=1)
 fftw_c2c_2d(data, inverse=0)
+fftw_c2c_xd(data, inverse=0)
 }
 \arguments{
-  \item{data}{(complex or real) matrix to be processed}
+  \item{data}{(complex or real) matrix to be processed (or array for \code{fftw_c2c_xd})}
   \item{inverse}{(integer) 1 or 0 indicating if inverse FFT is
     preformed. The return follows the format of the R FFT commands--the
     output is not scaled.}
   \item{HermConj}{(integer) 1 or 0 indicating if either "Hermitian" redundant
     conjugate should be returned.}
 }
-\author{Karim Rahim}
+\author{Karim Rahim and Ege Rubak}
 \examples{
 x=c(1, 2, 3, 9, 8, 5, 1, 2, 9, 8, 7, 2)
 x= t(matrix(x, nrow=4))
@@ -63,5 +67,7 @@ fftw2d(fftw2d(x), inverse=1)/12
 fftw2d(fftw2d(t(x)), inverse=1)/12
 fftw_r2c_2d(x)
 fftw_r2c_2d(x, HermConj=0)
+
+fftw_c2c_xd(x)
 }
 \keyword{fftw}

--- a/src/fftwtools.c
+++ b/src/fftwtools.c
@@ -191,3 +191,22 @@ void cfft_c2c_2d(int* nx, int* ny, double complex* data,
     
     fftw_destroy_plan(p);
 } 
+
+void cfft_c2c_xd(int* r, int* n, double complex* data,
+                 double complex* res, int* inverse) {
+
+    int sign;
+    fftw_plan p;
+
+    if(*inverse == 1) {
+        sign = FFTW_BACKWARD;
+    } else {
+        sign = FFTW_FORWARD;
+    }
+
+    p = fftw_plan_dft(*r, n, data, res, sign, FFTW_ESTIMATE);
+
+    fftw_execute(p);
+
+    fftw_destroy_plan(p);
+}

--- a/src/fftwtools.h
+++ b/src/fftwtools.h
@@ -53,5 +53,8 @@ void cfft_r2c_2d(int* nx, int* ny, double* data, double complex* res);
 void cfft_c2c_2d(int* nx, int* ny, double complex* data, 
                 double complex* res, int* inverse);
 
+void cfft_c2c_xd(int* r, int* n, double complex* data,
+                double complex* res, int* inverse);
+
 #endif
 

--- a/src/fftwtools_init.c
+++ b/src/fftwtools_init.c
@@ -8,6 +8,7 @@
 /* .C calls */
 extern void cfft_c2c(void *, void *, void *, void *);
 extern void cfft_c2c_2d(void *, void *, void *, void *, void *);
+extern void cfft_c2c_xd(void *, void *, void *, void *, void *);
 extern void cfft_c2r(void *, void *, void *);
 extern void cfft_r2c(void *, void *, void *, void *);
 extern void cfft_r2c_2d(void *, void *, void *, void *);
@@ -18,6 +19,7 @@ extern void cmvfft_r2c(void *, void *, void *, void *, void *);
 static const R_CMethodDef CEntries[] = {
     {"cfft_c2c",    (DL_FUNC) &cfft_c2c,    4},
     {"cfft_c2c_2d", (DL_FUNC) &cfft_c2c_2d, 5},
+    {"cfft_c2c_xd", (DL_FUNC) &cfft_c2c_xd, 5},
     {"cfft_c2r",    (DL_FUNC) &cfft_c2r,    3},
     {"cfft_r2c",    (DL_FUNC) &cfft_r2c,    4},
     {"cfft_r2c_2d", (DL_FUNC) &cfft_r2c_2d, 4},


### PR DESCRIPTION
Hi, I've added a function `fftw_c2c_xd` for general dimensional arrays analogous to `fftw_c2c_2d`. I hope you find the suggestion useful. Of course you are free to rename it to anything you like.