### PR TITLE
Adds fftw3d and related functions for 3D FFT

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,3 +1,3 @@
 #exportPattern("^[^\\.]")
-export( fftw, fftw2d, fftw_c2c, fftw_c2c_2d, fftw_c2c_xd, fftw_c2r, fftw_r2c, fftw_r2c_2d, mvfftw, mvfftw_c2c, mvfftw_c2r, mvfftw_r2c)
+export( fftw, fftw2d, fftw3d, fftw_c2c, fftw_c2c_2d, fftw_c2c_3d, fftw_c2c_xd, fftw_c2r, fftw_r2c, fftw_r2c_2d, fftw_r2c_3d, mvfftw, mvfftw_c2c, mvfftw_c2r, mvfftw_r2c)
 useDynLib(fftwtools, .registration = TRUE)

--- a/man/fftw3d.Rd
+++ b/man/fftw3d.Rd
@@ -1,0 +1,66 @@
+%     The fftwtools R package
+%     fftw2d and general mvfftw tools in R
+%     Copyright (C) 2013 Karim Rahim 
+%
+%     Written by Karim Rahim.
+%
+%     This file is part of the fftwtools package for R.
+%
+%     The fftwtools package is free software: you can redistribute it and
+%     or modify it under the terms of the GNU General Public License as 
+%     published by the Free Software Foundation, either version 2 of the 
+%     License, or any later version.
+%
+%     The fftwtools package is distributed in the hope that it will be 
+%     useful, but WITHOUT ANY WARRANTY; without even the implied warranty 
+%     of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+%     GNU General Public License for more details.
+%
+%     You should have received a copy of the GNU General Public License
+%     along with fftwtools.  If not, see <http://www.gnu.org/licenses/>.
+%
+%     If you wish to report bugs please contact the author. 
+%     karim.rahim@gmail.com
+%     Jeffery Hall, Queen's University, Kingston Ontario
+%     Canada, K7L 3N6
+
+\name{fftw3d}
+\alias{fftw3d}
+\alias{fftw_c2c_3d}
+\alias{fftw_r2c_3d}
+\title{Compute a two-dimensional FFT on a matrix using FFTW3}
+\description{
+Computes three-dimensional FFT on an array using the FFTW3 libraries.
+Use fftw_r2c_3d(x, HermConj=0) for real to complex FFT. This will
+return the result without the "Hermitian" redundancy. These functions follow the R
+convention when returning the inverse of the FFT. For the two-dimension
+fft, the inverse is currently requires the entire matrix, including the
+redundant complex conjugate.
+}
+\usage{
+fftw3d(data, inverse=0, HermConj=1)
+fftw_r2c_3d(data, HermConj=1)
+fftw_c2c_3d(data, inverse=0)
+}
+\arguments{
+\item{data}{(complex or real) 3-dimensional array to be processed}
+\item{inverse}{(integer) 1 or 0 indicating if inverse FFT is
+preformed. The return follows the format of the R FFT commands--the
+output is not scaled.}
+\item{HermConj}{(integer) 1 or 0 indicating if either "Hermitian" redundant
+conjugate should be returned.}
+}
+\author{Karim Rahim}
+\examples{
+x=c(1, 2, 3, 9, 8, 5, 1, 2, 9, 8, 7, 2)
+x= array(x, dim=c(3,2,2))
+
+fftw3d(x)
+fftw3d(x, HermConj=0)
+
+fftw3d(fftw3d(x), inverse=1)/12
+
+fftw_r2c_3d(x)
+fftw_r2c_3d(x, HermConj=0)
+}
+\keyword{fftw}

--- a/src/fftwtools.c
+++ b/src/fftwtools.c
@@ -192,6 +192,39 @@ void cfft_c2c_2d(int* nx, int* ny, double complex* data,
     fftw_destroy_plan(p);
 } 
 
+void cfft_r2c_3d(int* nx, int* ny, int *nz, double* data, double complex* res) {
+
+  fftw_plan p;
+
+  p = fftw_plan_dft_r2c_3d(*nx, *ny, *nz, data, res,
+                           FFTW_ESTIMATE);
+
+  fftw_execute(p);
+
+  fftw_destroy_plan(p);
+}
+
+
+void cfft_c2c_3d(int* nx, int* ny, int *nz, double complex* data,
+                 double complex* res, int* inverse) {
+
+  int sign;
+  fftw_plan p;
+
+  if(*inverse == 1) {
+    sign = FFTW_BACKWARD;
+  } else {
+    sign = FFTW_FORWARD;
+  }
+
+  p = fftw_plan_dft_3d(*nx, *ny, *nz, data, res,
+                       sign, FFTW_ESTIMATE);
+
+  fftw_execute(p);
+
+  fftw_destroy_plan(p);
+}
+
 void cfft_c2c_xd(int* r, int* n, double complex* data,
                  double complex* res, int* inverse) {
 

--- a/src/fftwtools.h
+++ b/src/fftwtools.h
@@ -53,6 +53,11 @@ void cfft_r2c_2d(int* nx, int* ny, double* data, double complex* res);
 void cfft_c2c_2d(int* nx, int* ny, double complex* data, 
                 double complex* res, int* inverse);
 
+void cfft_r2c_3d(int* nx, int* ny, int *nz, double* data, double complex* res);
+
+void cfft_c2c_3d(int* nx, int* ny, int *nz, double complex* data, 
+                 double complex* res, int* inverse);
+
 void cfft_c2c_xd(int* r, int* n, double complex* data,
                 double complex* res, int* inverse);
 

--- a/src/fftwtools_init.c
+++ b/src/fftwtools_init.c
@@ -8,10 +8,12 @@
 /* .C calls */
 extern void cfft_c2c(void *, void *, void *, void *);
 extern void cfft_c2c_2d(void *, void *, void *, void *, void *);
+extern void cfft_c2c_3d(void *, void *, void *, void *, void *, void *);
 extern void cfft_c2c_xd(void *, void *, void *, void *, void *);
 extern void cfft_c2r(void *, void *, void *);
 extern void cfft_r2c(void *, void *, void *, void *);
 extern void cfft_r2c_2d(void *, void *, void *, void *);
+extern void cfft_r2c_3d(void *, void *, void *, void *, void *);
 extern void cmvfft_c2c(void *, void *, void *, void *, void *, void *);
 extern void cmvfft_c2r(void *, void *, void *, void *, void *);
 extern void cmvfft_r2c(void *, void *, void *, void *, void *);
@@ -19,10 +21,12 @@ extern void cmvfft_r2c(void *, void *, void *, void *, void *);
 static const R_CMethodDef CEntries[] = {
     {"cfft_c2c",    (DL_FUNC) &cfft_c2c,    4},
     {"cfft_c2c_2d", (DL_FUNC) &cfft_c2c_2d, 5},
+    {"cfft_c2c_3d", (DL_FUNC) &cfft_c2c_3d, 6},
     {"cfft_c2c_xd", (DL_FUNC) &cfft_c2c_xd, 5},
     {"cfft_c2r",    (DL_FUNC) &cfft_c2r,    3},
     {"cfft_r2c",    (DL_FUNC) &cfft_r2c,    4},
     {"cfft_r2c_2d", (DL_FUNC) &cfft_r2c_2d, 4},
+    {"cfft_r2c_3d", (DL_FUNC) &cfft_r2c_3d, 5},
     {"cmvfft_c2c",  (DL_FUNC) &cmvfft_c2c,  6},
     {"cmvfft_c2r",  (DL_FUNC) &cmvfft_c2r,  5},
     {"cmvfft_r2c",  (DL_FUNC) &cmvfft_r2c,  5},


### PR DESCRIPTION
This just implements the 3D versions of FFT in the same way the 2D ones are implemented. Would be nice to have this in the package by default.

(I guess also the full multivariate one I suppose?)

Tested and confirmed identical to stats::fft on 3D arrays.